### PR TITLE
Add tests for the steering behavior

### DIFF
--- a/src/main/scala/com/agar/core/behaviors/Behavior.scala
+++ b/src/main/scala/com/agar/core/behaviors/Behavior.scala
@@ -5,6 +5,8 @@ import com.agar.core.utils.Vector2d
 object Behavior {
   type Steering = Vector2d
 
+  case class TargetEntity(position: Vector2d, velocity: Vector2d)
+
   // Get the steering force that make the character run toward the target
   def seek(target: Vector2d, position: Vector2d, velocity: Vector2d, maxVelocity: Short): Steering = {
     val desiredVelocity = (target - position).normalize() * maxVelocity
@@ -21,19 +23,23 @@ object Behavior {
 
   // The pursuit behavior works pretty much the same way seek does,
   // the only difference is that the pursuer will not seek the target itself, but its position in the near future.
-  // TODO: please change the signature of target... really please
-  def pursuit(target: (Vector2d, Vector2d) , position: Vector2d, velocity: Vector2d, maxVelocity: Short): Steering = {
-    val futurePosition = target._1 + target._2 * maxVelocity
-    seek(futurePosition, position, velocity, maxVelocity)
+  def pursuit(target: TargetEntity, position: Vector2d, velocity: Vector2d, maxVelocity: Short): Steering = {
+    val targetFuturePosition = getFuturPositionAccordingTo(target, position, maxVelocity)
+    seek(targetFuturePosition, position, velocity, maxVelocity)
   }
 
   // The evade behavior is the opposite of the pursuit behavior.
   // Instead of seeking the target's future position, in the evade behavior the character will flee that position:
-  // TODO: please change the signature of target... really please
-  def evade(target: (Vector2d, Vector2d) , position: Vector2d, velocity: Vector2d, maxVelocity: Short): Steering = {
-    val distance = target._1 - position
-    var updatesAhead = distance.magnitude() / maxVelocity
-    val futurePosition = target._1 + target._2 * maxVelocity
-    flee(futurePosition, position, velocity, maxVelocity)
+  def evade(target: TargetEntity, position: Vector2d, velocity: Vector2d, maxVelocity: Short): Steering = {
+    val targetFuturePosition = getFuturPositionAccordingTo(target, position, maxVelocity)
+    flee(targetFuturePosition, position, velocity, maxVelocity)
+  }
+
+  // Get the futur position of an entity according to the position of another entity
+  private def getFuturPositionAccordingTo(target: TargetEntity, position: Vector2d, maxVelocity: Short): Vector2d = {
+    val distance = target.position - position
+    val updatesNeeded = distance.magnitude() / maxVelocity
+    val tv = target.velocity  * updatesNeeded
+    target.velocity + tv
   }
 }

--- a/src/main/scala/com/agar/core/utils/Vector2d.scala
+++ b/src/main/scala/com/agar/core/utils/Vector2d.scala
@@ -48,4 +48,21 @@ class Vector2d(val x: Double, val y: Double) {
 
   /** Returns the length of the vector |a| = sqrt((ax * ax) + (ay * ay) + (az * az)) */
   def magnitude(): Double = Math.sqrt((x * x) + (y * y))
+
+  def canEqual(other: Any): Boolean =
+    other.isInstanceOf[Vector2d]
+
+  override def equals(other: Any): Boolean = {
+    other match {
+      case that: Vector2d =>
+        that.canEqual(Vector2d.this) &&
+          x == that.x &&
+          y == that.y
+      case _ => false
+    }
+  }
+
+  override def toString(): String = {
+    "Vector2d< x:" + x + ", y:" + y + ">"
+  }
 }

--- a/src/main/scala/com/agar/core/utils/Vector2d.scala
+++ b/src/main/scala/com/agar/core/utils/Vector2d.scala
@@ -36,12 +36,16 @@ class Vector2d(val x: Double, val y: Double) {
   /** Returns the dot product of two vectors. */
   def dot(v: Vector2d): Double = x * v.x + y * v.y
 
-  /** Returns a unit vector in the direction of this vector. */
-  def normalize(): Vector2d = this / this.dot(this)
+  /** Returns a unit vector in the direction of this vector.
+    * x = ax / |a|
+    * y = ay / |a|
+    * z = az / |a|
+    * */
+  def normalize(): Vector2d = this / this.magnitude()
 
   /** Returns the projection of this vector onto v. */
   def proj(v: Vector2d): Vector2d = v * (this.dot(v) / v.dot(v))
 
-  /** Returns the length of the vector */
+  /** Returns the length of the vector |a| = sqrt((ax * ax) + (ay * ay) + (az * az)) */
   def magnitude(): Double = Math.sqrt((x * x) + (y * y))
 }

--- a/src/test/scala/com/agar/core/behaviors/BehaviorsSpec.scala
+++ b/src/test/scala/com/agar/core/behaviors/BehaviorsSpec.scala
@@ -1,0 +1,41 @@
+package com.agar.core.behaviors
+
+import com.agar.core.behaviors.Behavior.TargetEntity
+import com.agar.core.utils.Vector2d
+import org.scalatest.{FlatSpec, Matchers}
+
+import scala.language.postfixOps
+
+
+class BehaviorsSpec() extends FlatSpec with Matchers {
+
+  val MAX_VELOCITY = 3:Short
+
+  "An entity" should "move toward the target with steer behavior" in {
+    val target = new Vector2d(40, 70)
+    val pos = new Vector2d(80, 60)
+    val vel = new Vector2d(2, 2)
+    Behavior.seek(target, pos, vel, MAX_VELOCITY) should be (new Vector2d(-4.910427500435995, -1.2723931248910012))
+  }
+
+  "An entity" should "run away from the target with flee behavior" in {
+    val target = new Vector2d(90, 60)
+    val pos = new Vector2d(80, 60)
+    val vel = new Vector2d(2, 2)
+    Behavior.flee(target, pos, vel, MAX_VELOCITY) should be (new Vector2d(-5, -2))
+  }
+
+  "An entity" should "be able to pursuit a target" in {
+    val target = new TargetEntity(new Vector2d(40, 70), new Vector2d(2, 2))
+    val pos = new Vector2d(80, 60)
+    val vel = new Vector2d(2, 2)
+    Behavior.pursuit(target, pos, vel, MAX_VELOCITY) should be (new Vector2d(-4.567868516922847, -3.5511451511049703))
+  }
+
+  "An entity" should "be evade from a pursuer" in {
+    val target = new TargetEntity(new Vector2d(40, 70), new Vector2d(2, 2))
+    val pos = new Vector2d(80, 60)
+    val vel = new Vector2d(2, 2)
+    Behavior.evade(target, pos, vel, MAX_VELOCITY) should be (new Vector2d(0.5678685169228461, -0.44885484889502947))
+  }
+}


### PR DESCRIPTION
Work to complete #1 #2 #3 

This PR:
- Fix the behavior pursuit and evade
- Add unit tests for all current behaviors
- Refactor the `target:(Vector2d, Vector2d)` => `case class Target(position: Vector2d, velocity: Vector2d)`
- Fix `normalize()` in Vector2d

Please help if you know how to compare 2 double with just a precision at 10^-2. I need to dos this:
`should be (new Vector2d(-4.567868516922847, -3.5511451511049703))` but I'll prefer something like `should be (new Vector2d(-4.56, -3.55))`

For now, my test look like this:
```
"An entity" should "...." in {

 }

"An entity" should "....." in {

  }
```

But that give me this output in the test repport:
```
[info] An entity
[info] - should move toward the target with steer behavior
[info] An entity
[info] - should run away from the target with flee behavior
[info] An entity
[info] - should be able to pursuit a target
[info] An entity
```

Where I prefer something like (only one "An entity"):
```
[info] An entity
[info] - should move toward the target with steer behavior
[info] - should run away from the target with flee behavior
[info] - should be able to pursuit a target
```

I tried to make my code like that:
```
class Yolo extend FlatSpec with Matchers with WordSpecLike {
  "An entity" should{
      "...." in {

      "....." in {
     }
   }
}
```

but I got this error:
```
[info] Loading settings from plugins.sbt ...
[info] Loading project definition from /home/alessio/Talks/Actor/agar.core/project
[info] Loading settings from build.sbt ...
[info] Set current project to agar.core (in build file:/home/alessio/Talks/Actor/agar.core/)
[info] Compiling 1 Scala source to /home/alessio/Talks/Actor/agar.core/target/scala-2.12/test-classes ...
[error] /home/alessio/Talks/Actor/agar.core/src/test/scala/com/agar/core/behaviors/BehaviorsSpec.scala:9:7: class BehaviorsSpec inherits conflicting members:
[error]   method info in trait FlatSpecLike of type => org.scalatest.Informer  and
[error]   method info in trait WordSpecLike of type => org.scalatest.Informer
[error] (Note: this can be resolved by declaring an override in class BehaviorsSpec.);
[error]  other members with override errors are: note, alert, markup, registerTest, registerIgnoredTest, it, they, behave, styleName
[error] class BehaviorsSpec() extends FlatSpec with Matchers with WordSpecLike{
[error]       ^
[error] one error found
[error] (Test / compileIncremental) Compilation failed
[error] Total time: 3 s, completed Nov 6, 2018 1:01:25 AM
```
What I understand is the combo with ` extend FlatSpec with Matchers with WordSpecLike` is not correct.