### PR TITLE
Add energy actor

### DIFF
--- a/src/main/scala/com/agar/core/energy/Energy.scala
+++ b/src/main/scala/com/agar/core/energy/Energy.scala
@@ -1,0 +1,28 @@
+package com.agar.core.energy
+
+import akka.actor.{Actor, Props}
+import com.agar.core.energy.Energy.{Consume, Consumed}
+
+object Energy {
+  def props(value: Int): Props = Props(new Energy(value))
+
+  case object Consume
+
+  case class Consumed(value: Int)
+
+}
+
+class Energy(value: Int) extends Actor {
+
+  def receive: PartialFunction[Any, Unit] = {
+    case Consume =>
+      sender ! Consumed(value)
+      context.become(consumed)
+  }
+
+  def consumed: PartialFunction[Any, Unit] = {
+    case Consume =>
+      ()
+  }
+
+}

--- a/src/test/scala/com/agar/core/energy/EnergySpec.scala
+++ b/src/test/scala/com/agar/core/energy/EnergySpec.scala
@@ -1,0 +1,49 @@
+package com.agar.core.energy
+
+import akka.actor.ActorSystem
+import akka.testkit.{ImplicitSender, TestKit}
+import com.agar.core.energy.Energy.{Consume, Consumed}
+import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpecLike}
+
+import scala.concurrent.duration._
+import scala.language.postfixOps
+
+//#test-classes
+class EnergySpec(_system: ActorSystem)
+  extends TestKit(_system)
+    with ImplicitSender
+    with Matchers
+    with WordSpecLike
+    with BeforeAndAfterAll {
+
+  def this() = this(ActorSystem("AgarSpec"))
+
+  override def afterAll: Unit = {
+    shutdown(system)
+  }
+
+  "An Energy Actor" should {
+    "can be consumed" in {
+
+      val energy = system.actorOf(Energy.props(10))
+
+      energy ! Consume
+      this.expectMsg(500 millis, Consumed(10))
+
+    }
+
+    "can be consumed only once" in {
+
+      val energy = system.actorOf(Energy.props(10))
+
+      energy ! Consume
+      this.expectMsg(500 millis, Consumed(10))
+
+      energy ! Consume
+      this.expectNoMessage(500 millis)
+
+    }
+  }
+
+}
+


### PR DESCRIPTION
Complete #18 

This PR:

- Provides an energy actor managing 'Consume' message
- Related unit tests

Note: When testing single Akka actor the ImplicitSender trait let us use the test as an actor. Therefor expected messaged can be used.

```scala
class EnergySpec(_system: ActorSystem)
  extends TestKit(_system)
    with ImplicitSender
    with Matchers
    with WordSpecLike
    with BeforeAndAfterAll {

  "An Energy Actor" should {
    "can be consumed" in {
      val energy = system.actorOf(Energy.props(10))
      energy ! Consume
      this.expectMsg(500 millis, Consumed(10))
    }
    // ...
}
```