### PR TITLE
Normalise tests

### DIFF
--- a/src/main/scala/com/agar/core/energy/Energy.scala
+++ b/src/main/scala/com/agar/core/energy/Energy.scala
@@ -1,0 +1,28 @@
+package com.agar.core.energy
+
+import akka.actor.{Actor, Props}
+import com.agar.core.energy.Energy.{Consume, Consumed}
+
+object Energy {
+  def props(value: Int): Props = Props(new Energy(value))
+
+  case object Consume
+
+  case class Consumed(value: Int)
+
+}
+
+class Energy(value: Int) extends Actor {
+
+  def receive: PartialFunction[Any, Unit] = {
+    case Consume =>
+      sender ! Consumed(value)
+      context.become(consumed)
+  }
+
+  def consumed: PartialFunction[Any, Unit] = {
+    case Consume =>
+      ()
+  }
+
+}

--- a/src/test/scala/com/agar/core/arbitrator/ArbitratorSpec.scala
+++ b/src/test/scala/com/agar/core/arbitrator/ArbitratorSpec.scala
@@ -27,7 +27,7 @@ class ArbitratorSpec(_system: ActorSystem)
   }
 
   "A Player Actor" should {
-    "by created when a game is started" in {
+    "be created when a game is started" in {
 
       implicit val context: AgarContext = new AgarContext {
         override val system: AgarSystem = () => 5 seconds
@@ -42,9 +42,7 @@ class ArbitratorSpec(_system: ActorSystem)
 
       testProbe.expectMsg(500 millis, PlayerCreated(0, Point2d(0, 0)))
     }
-  }
 
-  "A Player Actor" should {
     "move once a game has been started" in {
 
       implicit val context: AgarContext = new AgarContext {
@@ -61,9 +59,7 @@ class ArbitratorSpec(_system: ActorSystem)
       testProbe.expectMsg(500 millis, PlayerCreated(0, Point2d(0, 0)))
       testProbe.expectMsg(500 millis, PlayerMoved(0, Point2d(1, 1)))
     }
-  }
 
-  "A Player Actor" should {
     "be create and destroyed due to timeout" in {
 
       implicit val context: AgarContext = new AgarContext {

--- a/src/test/scala/com/agar/core/behaviors/BehaviorsSpec.scala
+++ b/src/test/scala/com/agar/core/behaviors/BehaviorsSpec.scala
@@ -2,40 +2,42 @@ package com.agar.core.behaviors
 
 import com.agar.core.behaviors.Behavior.TargetEntity
 import com.agar.core.utils.Vector2d
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.{FlatSpec, Matchers, WordSpec}
 
 import scala.language.postfixOps
 
 
-class BehaviorsSpec() extends FlatSpec with Matchers {
+class BehaviorsSpec() extends WordSpec with Matchers {
 
   val MAX_VELOCITY = 3:Short
 
-  "An entity" should "move toward the target with steer behavior" in {
-    val target = new Vector2d(40, 70)
-    val pos = new Vector2d(80, 60)
-    val vel = new Vector2d(2, 2)
-    Behavior.seek(target, pos, vel, MAX_VELOCITY) should be (new Vector2d(-4.910427500435995, -1.2723931248910012))
-  }
+  "An entity" should {
+    "move toward the target with steer behavior" in {
+      val target = new Vector2d(40, 70)
+      val pos = new Vector2d(80, 60)
+      val vel = new Vector2d(2, 2)
+      Behavior.seek(target, pos, vel, MAX_VELOCITY) should be(new Vector2d(-4.910427500435995, -1.2723931248910012))
+    }
 
-  "An entity" should "run away from the target with flee behavior" in {
-    val target = new Vector2d(90, 60)
-    val pos = new Vector2d(80, 60)
-    val vel = new Vector2d(2, 2)
-    Behavior.flee(target, pos, vel, MAX_VELOCITY) should be (new Vector2d(-5, -2))
-  }
+    "run away from the target with flee behavior" in {
+      val target = new Vector2d(90, 60)
+      val pos = new Vector2d(80, 60)
+      val vel = new Vector2d(2, 2)
+      Behavior.flee(target, pos, vel, MAX_VELOCITY) should be(new Vector2d(-5, -2))
+    }
 
-  "An entity" should "be able to pursuit a target" in {
-    val target = new TargetEntity(new Vector2d(40, 70), new Vector2d(2, 2))
-    val pos = new Vector2d(80, 60)
-    val vel = new Vector2d(2, 2)
-    Behavior.pursuit(target, pos, vel, MAX_VELOCITY) should be (new Vector2d(-4.567868516922847, -3.5511451511049703))
-  }
+    "be able to pursuit a target" in {
+      val target = new TargetEntity(new Vector2d(40, 70), new Vector2d(2, 2))
+      val pos = new Vector2d(80, 60)
+      val vel = new Vector2d(2, 2)
+      Behavior.pursuit(target, pos, vel, MAX_VELOCITY) should be(new Vector2d(-4.567868516922847, -3.5511451511049703))
+    }
 
-  "An entity" should "be evade from a pursuer" in {
-    val target = new TargetEntity(new Vector2d(40, 70), new Vector2d(2, 2))
-    val pos = new Vector2d(80, 60)
-    val vel = new Vector2d(2, 2)
-    Behavior.evade(target, pos, vel, MAX_VELOCITY) should be (new Vector2d(0.5678685169228461, -0.44885484889502947))
+    "be evade from a pursuer" in {
+      val target = new TargetEntity(new Vector2d(40, 70), new Vector2d(2, 2))
+      val pos = new Vector2d(80, 60)
+      val vel = new Vector2d(2, 2)
+      Behavior.evade(target, pos, vel, MAX_VELOCITY) should be(new Vector2d(0.5678685169228461, -0.44885484889502947))
+    }
   }
 }

--- a/src/test/scala/com/agar/core/energy/EnergySpec.scala
+++ b/src/test/scala/com/agar/core/energy/EnergySpec.scala
@@ -1,0 +1,49 @@
+package com.agar.core.energy
+
+import akka.actor.ActorSystem
+import akka.testkit.{ImplicitSender, TestKit}
+import com.agar.core.energy.Energy.{Consume, Consumed}
+import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpecLike}
+
+import scala.concurrent.duration._
+import scala.language.postfixOps
+
+//#test-classes
+class EnergySpec(_system: ActorSystem)
+  extends TestKit(_system)
+    with ImplicitSender
+    with Matchers
+    with WordSpecLike
+    with BeforeAndAfterAll {
+
+  def this() = this(ActorSystem("AgarSpec"))
+
+  override def afterAll: Unit = {
+    shutdown(system)
+  }
+
+  "An Energy Actor" should {
+    "can be consumed" in {
+
+      val energy = system.actorOf(Energy.props(10))
+
+      energy ! Consume
+      this.expectMsg(500 millis, Consumed(10))
+
+    }
+
+    "can be consumed only once" in {
+
+      val energy = system.actorOf(Energy.props(10))
+
+      energy ! Consume
+      this.expectMsg(500 millis, Consumed(10))
+
+      energy ! Consume
+      this.expectNoMessage(500 millis)
+
+    }
+  }
+
+}
+


### PR DESCRIPTION
This PR normalise tests replacing flat spec style be grouped specs style.

Therefor Behavior tests (for instance) has the following form:
```scala
class BehaviorsSpec() extends WordSpec with Matchers {

  val MAX_VELOCITY = 3:Short

  "An entity" should {
    "move toward the target with steer behavior" in {
      ...
    }

    "run away from the target with flee behavior" in {
      ...
    }

    "be able to pursuit a target" in {
     ...
    }

    "be evade from a pursuer" in {
      ...
    }
  }
}
```

Then tests outputs are:
```term
[info] BehaviorsSpec:
[info] An entity
[info] - should move toward the target with steer behavior
[info] - should run away from the target with flee behavior
[info] - should be able to pursuit a target
[info] - should be evade from a pursuer
```